### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Simple settings management for ESP8266
 paragraph=
 category=Data Storage
 architectures=esp8266
-includes=src/settingsManager.h
+includes=settingsManager.h
 url=http://github.com/marecl


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > settingsManager**. Since this library is in the 1.5 library format, the src folder is in the include search path, and so the `#include` directive should not specify the `src` folder in the path. The previous use of `src/settingsManager.h` in the `includes` file caused an `#include` directive to be inserted in the sketch which resulted in a compilation error:
```
sketch_may11a:1:10: error: src/settingsManager.h: No such file or directory

 #include <src/settingsManager.h>

          ^~~~~~~~~~~~~~~~~~~~~~~
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format